### PR TITLE
Add type safety to constants

### DIFF
--- a/src/pages/projEstimate/QuoteTable/InputCellContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/InputCellContent.tsx
@@ -1,17 +1,23 @@
-import { debounce, FormControl, FormHelperText, Input, MenuItem, Select, Typography } from '@mui/material';
+import { debounce, 
+  FormControl, FormHelperText, Input, MenuItem, Select, Typography } from '@mui/material';
 import { useField } from 'formik';
 import { materialsLabelList } from '../constantDefinition';
+import { TKMaterials } from '../form';
 import quotePulldown from '../helpers/quotePulldown';
 
-export type InputCellContentProps = {
-  name: string,
-  /* value: string, */
-};
 
-const InputCellContent = (props: InputCellContentProps) => {
-  const [field, meta, helpers] = useField(props);
+
+const InputCellContent = ({
+  fieldName, rowIdx,
+}: {
+  fieldName: TKMaterials,
+  rowIdx: number
+}) => {
+  const arrayFieldName = `items[${rowIdx}][${fieldName}]`;
+
+  const [field, meta, helpers] = useField(arrayFieldName);
+
   const { error, touched } = meta;
-  const chkName = field.name.split('[')[2].replace(']', '');
 
   // INPUT用onchange処理
   const changeHandlerInput
@@ -22,9 +28,9 @@ const InputCellContent = (props: InputCellContentProps) => {
      helpers.setValue(el.target.value, true);
    }, 2000);
 
- 
-  if (materialsLabelList[chkName] === 'input') {
-    return (
+  switch (materialsLabelList[fieldName]) {
+
+    case 'input': return (
       <FormControl variant="standard">
         <Input {...field} error={!!error && touched} onChange={changeHandlerInput} value={undefined} />
         {(!!error && touched) &&
@@ -33,33 +39,34 @@ const InputCellContent = (props: InputCellContentProps) => {
           </FormHelperText>}
       </FormControl>
     );
-  } else if (materialsLabelList[chkName] === 'display') {
-    return (
+
+    case 'display': return (
       <Typography variant='body2'>
         {field.value + '円'}
       </Typography>
     );
-  } else if (materialsLabelList[chkName] === 'pulldown') {
-    const output: string[] = quotePulldown(chkName);
-    return (
-      <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }} size='small'>
-        <Select {...field}>
-          <MenuItem value="">
-            <em>-</em>
-          </MenuItem>
-          {output.map((item) => {
-            return (<MenuItem value={item} key={`${field.name}_${item}`}>{item}</MenuItem>);
-          })
+
+    case 'pulldown': return (() => {
+      const output: string[] = quotePulldown(fieldName);
+      return (
+        <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }} size='small'>
+          <Select {...field} >
+            <MenuItem value="">
+              <em>-</em>
+            </MenuItem>
+            {output.map((item) => {
+              return (<MenuItem value={item} key={`${field.name}_${item}`}>{item}</MenuItem>);
+            })
           }
-        </Select>
-        {(!!error && touched) &&
+          </Select>
+          {(!!error && touched) &&
           <FormHelperText error={!!error && touched}>
             {error}
           </FormHelperText>}
-      </FormControl>
-    );
-  } else if (materialsLabelList[chkName] === 'pullldownAndInput') {
-    return (
+        </FormControl>
+      );
+    })();
+    case 'pullldownAndInput': return (
       <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }}>
         <Select {...field}>
           <MenuItem value="">
@@ -71,10 +78,8 @@ const InputCellContent = (props: InputCellContentProps) => {
         </Select>
       </FormControl>
     );
+    default : return  (<div>表示エラーです</div>);
   }
-
-  /* エラー対策：default */
-  return (<div>表示エラーです</div>);
 
 };
 

--- a/src/pages/projEstimate/QuoteTable/RenderRows.tsx
+++ b/src/pages/projEstimate/QuoteTable/RenderRows.tsx
@@ -27,7 +27,7 @@ export default function RenderRows(props: RenderRowsProps) {
                 row={item}
                 rowIdx={itemsIdx}
                 removeRow={removeRow}
-                key={values.items[itemsIdx].number}
+                key={item.number}
               />
             );
           })}

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -2,8 +2,7 @@
 import { Button, TableCell, TableRow } from '@mui/material';
 import { useFormikContext } from 'formik';
 import { useEffect } from 'react';
-import { materialsLabelList } from '../constantDefinition';
-import { TypeOfForm } from '../form';
+import { TKMaterials, TypeOfForm } from '../form';
 import InputCellContent from './InputCellContent';
 
 export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
@@ -32,9 +31,8 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
     setFieldValue(`items[${rowIdx}].price`, Math.round(newPrice).toLocaleString());
 
   }, [costPrice, quantity, elemProfRate, tax]);
-
   return (<TableRow key={rowIdx}>
-    {Object.keys(row).map((rowitem, itemIdx) => {
+    {(Object.keys(row) as TKMaterials[]).map((rowitem) => {
       return (
         <TableCell
           key={`${rowitem}_header`}
@@ -43,7 +41,7 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
             verticalAlign: 'top',
           }}
         >
-          <InputCellContent name={`items[${rowIdx}][${Object.keys(materialsLabelList)[itemIdx]}]`} />
+          <InputCellContent fieldName={rowitem} rowIdx={rowIdx} />
         </TableCell>
       );
     })}

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -31,7 +31,7 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
     setFieldValue(`items[${rowIdx}].price`, Math.round(newPrice).toLocaleString());
 
   }, [costPrice, quantity, elemProfRate, tax]);
-  return (<TableRow key={rowIdx}>
+  return (<TableRow >
     {(Object.keys(row) as TKMaterials[]).map((rowitem) => {
       return (
         <TableCell

--- a/src/pages/projEstimate/constantDefinition.ts
+++ b/src/pages/projEstimate/constantDefinition.ts
@@ -1,3 +1,5 @@
+import { TKMaterials } from './form';
+
 /**
  * 見積もりテーブルの初期値
  */
@@ -18,7 +20,7 @@ export const buzaiListInit = {
 /**
  * 見積もりテーブルのkeyリスト
  */
-export const materialsLabelList = {
+export const materialsLabelList: Record<TKMaterials, 'display' | 'pulldown' | 'pullldownAndInput' | 'input'> = {
   'number': 'display',
   'majorItem': 'pulldown',
   'middleItem': 'pulldown',
@@ -30,14 +32,14 @@ export const materialsLabelList = {
   'tax': 'pulldown',
   'unitPrice': 'display',
   'price': 'display',
-};
+} as const;
 
 /**
  * 見積もりアイテムのラベル定義
  */
 export const materialsNameList = [
   'No.', '大項目*', '中項目', '部材', '原価*', '数量*', '利益率', '単位', '税(課税 / 非課税)', '単価', '金額',
-];
+] as const;
 
 /**
  * 合計欄のkeyリスト
@@ -51,4 +53,4 @@ export const materialsNameList = [
  */
 export const summaryNameList = [
   '原価合計', '粗利', '粗利率', '税(円)', '税抜金額', '税込金額',
-];
+] as const;


### PR DESCRIPTION
## 変更


- タイプの定義を追加しました。そして、それに依存しているところもリファクタリングしました。
- if-elseをswitchに変更しました。単純な `materialsLabelList[fieldName]` との比較なので、switchが向いているかなと思います。
https://qiita.com/ko8@github/items/f9aaf17c9c519386a961

そして、一回で　`materialsLabelList[fieldName]`　からデータを取得することでさらに最適化出来ます。


## なぜこの変更をするのか

タイプの定義をすることで、エラーやバグを未然に防止できます。例えば、form内容の変更の際、更新ミスによるバグが防止できます。

## 課題

基本的なタイプの定義です。まだ頑強ではないので、改善はまだまだ出来ます。

## 備考

日本語のプールリクエスト「PR」のテンプレートを探していて、以下のリンクを参考にしました。ルールではなく、とりあえずPR内容は自由です。
https://applis.io/posts/how-to-write-git-pull-request