### PR TITLE
RowContent/TableRowのキーを外しました。

### DIFF
--- a/src/pages/projEstimate/QuoteTable/RenderRows.tsx
+++ b/src/pages/projEstimate/QuoteTable/RenderRows.tsx
@@ -27,7 +27,7 @@ export default function RenderRows(props: RenderRowsProps) {
                 row={item}
                 rowIdx={itemsIdx}
                 removeRow={removeRow}
-                key={values.items[itemsIdx].number}
+                key={item.number}
               />
             );
           })}

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -31,7 +31,7 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
     setFieldValue(`items[${rowIdx}].price`, Math.round(newPrice).toLocaleString());
 
   }, [costPrice, quantity, elemProfRate, tax]);
-  return (<TableRow key={rowIdx}>
+  return (<TableRow >
     {(Object.keys(row) as TKMaterials[]).map((rowitem) => {
       return (
         <TableCell


### PR DESCRIPTION
元はPR #11です。

## 何

1. RowContent/TableRowのキーを外しました。

2. RenderRowのkeyをmapのitem.numberにしました。

## なぜ

1. mapのindexに依存しているので、削除・編集の際、全行がレンダリングされます。  
親要素にすでにkeyを定義しているので、なくてもいいと思います。

2. itemにnumberがあるので、それを使ったほうが、処理に軽いと思います。