### PR TITLE
単価と金額の算出処理の修正

### DIFF
--- a/src/pages/projEstimate/FormProjEstimate.tsx
+++ b/src/pages/projEstimate/FormProjEstimate.tsx
@@ -13,16 +13,48 @@ import { RenderFunc } from './QuoteTable/RenderFunc';
 export default function FormProjEstimate() {
   const { values, submitForm, setFieldValue } = useFormikContext<TypeOfForm>();
 
-  const costPriceFields = values.items.map(({ costPrice }) => costPrice);
+  // 原価合計の算出処理
+  const costPriceFields = values.items.map(({ costPrice, quantity }) => +costPrice * +quantity);
   const totalCostPrice = costPriceFields.reduce((acc, cur) => {
-    acc += +cur;
-    return acc;
+    return acc + cur;
   }, 0);
-  console.log('totalCostPrice', totalCostPrice);
 
+  // 粗利合計の算出処理
+  const grossProfitFields = values.items.map(({ costPrice, quantity, elemProfRate }) => {
+    return ((+costPrice * +quantity) * (+elemProfRate / 100));
+  });
+  const grossProfitVal = grossProfitFields.reduce((acc, cur) => {
+    return acc + cur;
+  }, 0);
+
+  // 利益率の算出処理
+  const provVal = (grossProfitVal / totalCostPrice) * 100;
+  const grossProfitMarginVal = isNaN(provVal) ? '-'
+    : parseFloat(provVal.toFixed(2));
+
+  // 税抜金額の算出処理
+  const taxExcludedAmountFields = values.items.map(({ costPrice, quantity, elemProfRate }) => {
+    return ((+costPrice * quantity) * (1 + (elemProfRate / 100)));
+  });
+  const taxExcludedAmountVal = taxExcludedAmountFields.reduce((acc, cur) => {
+    return acc + cur;
+  }, 0);
+
+  // 税込金額の算出処理
+  const amountIncludingTaxFields = values.items.map(({ price })=> +price);
+  const amountIncludingTaxVal = amountIncludingTaxFields.reduce((acc, cur) => {
+    return acc + cur;
+  }, 0);
+
+  // 合計欄の更新処理
   useEffect(() => {
-    setFieldValue('totalCost', totalCostPrice);
-  }, [totalCostPrice]);
+    setFieldValue('totalCost', Math.round(totalCostPrice));
+    setFieldValue('grossProfit', Math.round(grossProfitVal));
+    setFieldValue('grossProfitMargin', grossProfitMarginVal);
+    setFieldValue('taxAmount', Math.round(amountIncludingTaxVal - taxExcludedAmountVal));
+    setFieldValue('taxExcludedAmount', Math.round(taxExcludedAmountVal));
+    setFieldValue('amountIncludingTax', Math.round(amountIncludingTaxVal));
+  }, [totalCostPrice, grossProfitVal, grossProfitMarginVal, taxExcludedAmountVal, amountIncludingTaxVal]);
 
   /* フォームプルダウンに使用する配列の入れ物の定義 */
   /* フォームプルダウンに使用する配列の更新処理 */
@@ -69,6 +101,7 @@ export default function FormProjEstimate() {
           <Grid item md={3} />
 
           <Grid item xs={12} md={12}>
+            {/* 合計欄テーブル */}
             <SummaryTable />
           </Grid>
 

--- a/src/pages/projEstimate/QuoteTable/InputCellContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/InputCellContent.tsx
@@ -42,7 +42,7 @@ const InputCellContent = ({
 
     case 'display': return (
       <Typography variant='body2'>
-        {field.value + '円'}
+        {field.value.toLocaleString() + '円'}
       </Typography>
     );
 

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -17,20 +17,20 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
   // 各行の単価・金額の算出処理
   useEffect(() => {
     // 単価の算出処理 : IF(原価 <= 0, 0 , 原価  * ( 1 + (内訳利益率/100)))
-    const newUnitPrice = +(costPrice) <= 0 ? 0
-      : +(costPrice) * (1 + (elemProfRate) / 100);
-    setFieldValue(`items[${rowIdx}].unitPrice`, Math.round(newUnitPrice).toLocaleString());
+    const newUnitPrice = (isNaN(costPrice) || isNaN(elemProfRate)) ? '-'
+      : +(costPrice) <= 0 ? 0
+        : Math.round(+(costPrice) * (1 + (elemProfRate) / 100));
+    setFieldValue(`items[${rowIdx}].unitPrice`, newUnitPrice);
 
     // 金額の算出処理 : IF(原価 <= 0, 原価, IF ( 税="課税", (単価*数量) * (1 + (税率/100)), (単価*数量)))
-    const tentative = newUnitPrice * +quantity;
-
     const newPrice = +(costPrice) <= 0 ? costPrice
-      : (tax === '課税') ?
-        tentative * (1 + +(taxRate) / 100) : tentative;
-    // 金額を四捨五入で表示(切り捨ての場合はMath.ceil(数値)、切り捨ての場合はMath.floor(数値))
-    setFieldValue(`items[${rowIdx}].price`, Math.round(newPrice).toLocaleString());
+      : (newUnitPrice === '-' || isNaN(quantity)) ? '-'
+        : (tax === '課税') ? Math.round((newUnitPrice * +quantity) * (1 + +(taxRate) / 100))
+          : Math.round(newUnitPrice * +quantity);
+    setFieldValue(`items[${rowIdx}].price`, newPrice);
 
-  }, [costPrice, quantity, elemProfRate, tax]);
+  }, [costPrice, quantity, elemProfRate, tax, taxRate]);
+
   return (<TableRow >
     {(Object.keys(row) as TKMaterials[]).map((rowitem) => {
       return (

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -17,16 +17,23 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
   // 各行の単価・金額の算出処理
   useEffect(() => {
     // 単価の算出処理 : IF(原価 <= 0, 0 , 原価  * ( 1 + (内訳利益率/100)))
-    const newUnitPrice = (isNaN(costPrice) || isNaN(elemProfRate)) ? '-'
-      : +(costPrice) <= 0 ? 0
-        : Math.round(+(costPrice) * (1 + (elemProfRate) / 100));
+    let newUnitPrice = 0; // 入力値がエラー(数値でない)時は0にする
+    if (!(isNaN(costPrice) || isNaN(elemProfRate)) && ((costPrice) > 0)) {
+      newUnitPrice = Math.round(+costPrice * (1 + (+elemProfRate / 100)));
+    }
     setFieldValue(`items[${rowIdx}].unitPrice`, newUnitPrice);
 
     // 金額の算出処理 : IF(原価 <= 0, 原価, IF ( 税="課税", (単価*数量) * (1 + (税率/100)), (単価*数量)))
-    const newPrice = +(costPrice) <= 0 ? costPrice
-      : (newUnitPrice === '-' || isNaN(quantity)) ? '-'
-        : (tax === '課税') ? Math.round((newUnitPrice * +quantity) * (1 + +(taxRate) / 100))
-          : Math.round(newUnitPrice * +quantity);
+    let newPrice = 0; // 入力値がエラー(数値でない)時は0にする
+    if (+costPrice <= 0 ) {
+      newPrice = costPrice;
+    } else if ((newUnitPrice !== 0) && !(isNaN(quantity))) {
+      if (tax === '課税') {
+        newPrice = Math.round((newUnitPrice * +quantity) * (1 + (+taxRate / 100)));
+      } else { /* 非課税 */
+        newPrice = Math.round(newUnitPrice * +quantity);
+      }
+    }
     setFieldValue(`items[${rowIdx}].price`, newPrice);
 
   }, [costPrice, quantity, elemProfRate, tax, taxRate]);

--- a/src/pages/projEstimate/SummaryTable/DisplayCellContent.tsx
+++ b/src/pages/projEstimate/SummaryTable/DisplayCellContent.tsx
@@ -7,14 +7,14 @@ export type DisplayCellContentProps = {
 };
 const DisplayCellContent = (props: DisplayCellContentProps) => {
   const [field] = useField(props);
-  // const { values } = useFormikContext<TypeOfForm>();
 
-  /* 表示内容の算出処理 */
-  // const output = summaryCalcProcess(field, values);
-  
+  // 粗利率のみ単位を%、その他は3桁ごとにカンマ+単位に円を付与する
+  const dispVal = (field.name === 'grossProfitMargin') ? (field.value + ' %')
+    : (field.value.toLocaleString() + '円');
+
   return (
     <Typography variant='body2' >
-      {field.value}
+      {dispVal}
     </Typography>
   );
 };

--- a/src/pages/projEstimate/constantDefinition.ts
+++ b/src/pages/projEstimate/constantDefinition.ts
@@ -42,13 +42,6 @@ export const materialsNameList = [
 ] as const;
 
 /**
- * 合計欄のkeyリスト
- */
-/* export const summaryLabelList = [
-  'totalCost', 'grossProfit', 'grossProfitMargin', 'taxAmount', 'taxExcludedAmount', 'amountIncludingTax',
-]; */
-
-/**
  * 合計欄のラベル定義
  */
 export const summaryNameList = [


### PR DESCRIPTION
**変更**
---

- 単価と金額のフォームに,(カンマ)が入っていたため、削除しnumber型のデータに修正しました。
- 単価と金額の算出処理を修正しました。
　算出に使用する変数の型判定と、想定外の値の場合は'-'(ハイフン)表示にするよう変更しました。

**なぜこの変更をするのか**
---

- 合計値の算出処理に影響が出るため(フォームに格納する値のミスによる)
- 異常値で算出した際、結果が'NaN'と表示される対策