### PR TITLE
「大項目、中項目、部材」を取得するhookを追加しました。

### DIFF
--- a/src/hooks/usePromise.ts
+++ b/src/hooks/usePromise.ts
@@ -12,7 +12,6 @@ export const usePromise : UsePromise = ( promiseFunc, initialValue ) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(()=> {
-    console.log('EEEEEE', data);
     promiseFunc()
       .then(resp => setData(resp ))
       .catch(setError)

--- a/src/hooks/usePromise.ts
+++ b/src/hooks/usePromise.ts
@@ -1,15 +1,20 @@
 import { useEffect, useState } from 'react';
 
-type UsePromise = (promiseFunc: () => Promise<any>, initialValue?: null | object) => { data: object | null, error: object, loading: boolean };
+type UsePromise = <T>(
+  promiseFunc: () => Promise<any>, initialValue?: T
+  ) => {
+    data?: T, error: object, loading: boolean
+  };
 
-export const usePromise : UsePromise = ( promiseFunc, initialValue = null ) => {
+export const usePromise : UsePromise = ( promiseFunc, initialValue ) => {
   const [data, setData] = useState(initialValue);
   const [error, setError] = useState({});
   const [loading, setLoading] = useState(true);
 
   useEffect(()=> {
+    console.log('EEEEEE', data);
     promiseFunc()
-      .then(resp => setData(resp))
+      .then(resp => setData(resp ))
       .catch(setError)
       .finally(() => setLoading(false));
   }, [promiseFunc]);

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -5,7 +5,7 @@ import usePromise from './usePromise';
 type UseStores = () => ({ stores: Options });
 
 export const useStores : UseStores = () => {
-  const { data, error, loading } = usePromise(getStoresAsOptions);
+  const { data, error, loading } = usePromise<Options>(getStoresAsOptions);
 
   return {
     stores: (data as Options),

--- a/src/pages/projEstimate/api/__snapshots__/fetchMaterial.test.ts.snap
+++ b/src/pages/projEstimate/api/__snapshots__/fetchMaterial.test.ts.snap
@@ -294,3 +294,699 @@ Array [
   },
 ]
 `;
+
+exports[`Get Materials API should be able to get Materials 1`] = `
+Array [
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "7",
+    },
+    "中項目": Object {
+      "type": "NUMBER",
+      "value": "26",
+    },
+    "単位": Object {
+      "type": "DROP_DOWN",
+      "value": "台",
+    },
+    "原価": Object {
+      "type": "NUMBER",
+      "value": "1280",
+    },
+    "部材名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "点検口枠T(neo-V配合)",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "6",
+    },
+    "中項目": Object {
+      "type": "NUMBER",
+      "value": "26",
+    },
+    "単位": Object {
+      "type": "DROP_DOWN",
+      "value": "台",
+    },
+    "原価": Object {
+      "type": "NUMBER",
+      "value": "1590",
+    },
+    "部材名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "なんとか点検口",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "5",
+    },
+    "中項目": Object {
+      "type": "NUMBER",
+      "value": "12",
+    },
+    "単位": Object {
+      "type": "DROP_DOWN",
+      "value": "セット",
+    },
+    "原価": Object {
+      "type": "NUMBER",
+      "value": "100000",
+    },
+    "部材名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "Scaffolding",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "4",
+    },
+    "中項目": Object {
+      "type": "NUMBER",
+      "value": "6",
+    },
+    "単位": Object {
+      "type": "DROP_DOWN",
+      "value": "式",
+    },
+    "原価": Object {
+      "type": "NUMBER",
+      "value": "0",
+    },
+    "部材名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "-",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "3",
+    },
+    "中項目": Object {
+      "type": "NUMBER",
+      "value": "3",
+    },
+    "単位": Object {
+      "type": "DROP_DOWN",
+      "value": "袋",
+    },
+    "原価": Object {
+      "type": "NUMBER",
+      "value": "3000",
+    },
+    "部材名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "wewewewe",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "2",
+    },
+    "中項目": Object {
+      "type": "NUMBER",
+      "value": "21",
+    },
+    "単位": Object {
+      "type": "DROP_DOWN",
+      "value": "本",
+    },
+    "原価": Object {
+      "type": "NUMBER",
+      "value": "2000",
+    },
+    "部材名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "Plank",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "1",
+    },
+    "中項目": Object {
+      "type": "NUMBER",
+      "value": "1",
+    },
+    "単位": Object {
+      "type": "DROP_DOWN",
+      "value": null,
+    },
+    "原価": Object {
+      "type": "NUMBER",
+      "value": "1200",
+    },
+    "部材名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "部材1",
+    },
+  },
+]
+`;
+
+exports[`Get Materials API should be able to get MiddleItems 1`] = `
+Array [
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "42",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "補助制度申請費",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "30",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "41",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "建築確認申請費",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "30",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "40",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "住宅保証登録費",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "30",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "39",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "ｴｺｼﾞｮｰｽﾞ",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "19",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "38",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "ｴｺｷｭｰﾄ",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "19",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "37",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "手洗い器",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "19",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "36",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "2Fﾄｲﾚ",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "19",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "35",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "1Fﾄｲﾚ",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "19",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "34",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "洗面化粧台",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "19",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "33",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "ﾕﾆｯﾄﾊﾞｽ",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "19",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "32",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "ｶｯﾌﾟﾎﾞｰﾄﾞ",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "19",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "31",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "ｼｽﾃﾑｷｯﾁﾝ",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "19",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "30",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "ﾊﾞﾙｺﾆｰ笠木",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "29",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "29",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "破風鼻隠し",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "29",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "28",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "屋根葺き",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "29",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "27",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "床材、建具、階段材",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "27",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "26",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "壁点検口",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "27",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "25",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "床下点検口",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "27",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "24",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "荷揚げ・荷下ろし費",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "27",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "23",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "石膏ﾎﾞｰﾄﾞ　壁",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "27",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "22",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "石膏ﾎﾞｰﾄﾞ　天井",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "27",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "21",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "造作金物費用",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "6",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "20",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "造作基本工賃",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "6",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "19",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "上棟費",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "6",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "18",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "防蟻",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "4",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "17",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "産業廃棄物処理費",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "3",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "16",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "仮設ﾄｲﾚ等",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "3",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "15",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "養生ﾃｰﾌﾟ",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "3",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "14",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "養生ﾎﾞｰﾄﾞ",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "3",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "13",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "内部足場",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "3",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "12",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "外部足場使用料",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "3",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "11",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "重機回送費",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "2",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "10",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "残土処分費",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "2",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "9",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "雑コンクリート",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "2",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "8",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "ポンプ車",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "2",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "7",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "ベタ基礎",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "2",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "6",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "-",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "5",
+    },
+  },
+  Object {
+    "レコード番号": Object {
+      "type": "RECORD_NUMBER",
+      "value": "1",
+    },
+    "中項目名": Object {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "中項目テスト",
+    },
+    "大項目": Object {
+      "type": "NUMBER",
+      "value": "1",
+    },
+  },
+]
+`;

--- a/src/pages/projEstimate/api/config.ts
+++ b/src/pages/projEstimate/api/config.ts
@@ -46,7 +46,7 @@ KEstimateAppId,
   },
   elements: {
 
-    fields: ['部材名', '原価', '単位'] as Array<keyof Estimates.materials.SavedData>,
+    fields: ['部材名', 'レコード番号', '中項目', '原価', '単位'] as Array<keyof Estimates.materials.SavedData>,
     query: 'レコード番号 < 10',
   },
 };

--- a/src/pages/projEstimate/api/fetchMaterial.test.ts
+++ b/src/pages/projEstimate/api/fetchMaterial.test.ts
@@ -1,8 +1,18 @@
-import { fetchMajorItems } from './fetchMaterials';
+import { fetchMajorItems, fetchMaterials, fetchMiddleItems } from './fetchMaterials';
 
 describe('Get Materials API', () => {
   it('should be able to get MajorItems', async ()=>{
     const  result = await fetchMajorItems();
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should be able to get MiddleItems', async ()=>{
+    const  result = await fetchMiddleItems();
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should be able to get Materials', async ()=>{
+    const  result = await fetchMaterials();
     expect(result).toMatchSnapshot();
   });
 });

--- a/src/pages/projEstimate/api/fetchMaterials.ts
+++ b/src/pages/projEstimate/api/fetchMaterials.ts
@@ -6,15 +6,6 @@ import { fetchRecords } from './fetchRecords';
 */
 
 export const fetchMajorItems = () => fetchRecords('majourItems') as unknown as Promise<Estimates.majorItems.SavedData[]>;
-
-export const fetchMiddleItems = async () => {
-  return fetchRecords('middleItems') as unknown as Promise<Estimates.middleItems.SavedData[]>;
-};
-
+export const fetchMiddleItems = () => fetchRecords('middleItems') as unknown as Promise<Estimates.middleItems.SavedData[]>;
 export const fetchMaterials = () => fetchRecords('elements') as unknown as Promise<Estimates.materials.SavedData[]>;
 
-export const getMajorItems = fetchMajorItems()
-  .then(res => res.map(({ 大項目名 }) => 大項目名.value ));
-
-export const getMiddleItems = fetchMiddleItems()
-  .then(res => res.map(({ 中項目名 }) => 中項目名.value ));

--- a/src/pages/projEstimate/api/fetchRecords.ts
+++ b/src/pages/projEstimate/api/fetchRecords.ts
@@ -3,11 +3,13 @@ import { EstimateAppId, estimateFields, KEstimateAppId, KintoneEstimateRecord } 
 
 export const fetchRecords = async <T extends KEstimateAppId>(
   appName: T,
+  query?: string,
 ) => {
   return KintoneEstimateRecord.getRecords({
     app: EstimateAppId[appName],
     /* query: estimateFields[appName].query, */
     fields: estimateFields[appName].fields,
+    query,
   }).then(r => r.records);
 };
 

--- a/src/pages/projEstimate/hooks/useMaterials.ts
+++ b/src/pages/projEstimate/hooks/useMaterials.ts
@@ -1,13 +1,19 @@
 import { usePromise } from '../../../hooks';
 import { fetchMajorItems, fetchMiddleItems } from '../api/fetchMaterials';
 
-
+export type TMaterialOptions = {
+  majorItems: Estimates.majorItems.SavedData[],
+  middleItems: Estimates.middleItems.SavedData[],
+  materials: Estimates.materials.SavedData[],
+};
 
 /**
  * Cached all Materials and expose filter functions.
  *
  * This is to save API calls.
  */
+
+
 export const useMaterials  = () => {
   const majorItems = usePromise<Estimates.majorItems.SavedData[]>(fetchMajorItems);
   const middleItems = usePromise<Estimates.middleItems.SavedData[]>(fetchMiddleItems);

--- a/src/pages/projEstimate/hooks/useMaterials.ts
+++ b/src/pages/projEstimate/hooks/useMaterials.ts
@@ -11,7 +11,7 @@ import { fetchMajorItems, fetchMiddleItems } from '../api/fetchMaterials';
 export const useMaterials  = () => {
   const majorItems = usePromise<Estimates.majorItems.SavedData[]>(fetchMajorItems);
   const middleItems = usePromise<Estimates.middleItems.SavedData[]>(fetchMiddleItems);
-  const materials = usePromise<Estimates.middleItems.SavedData[]>(fetchMiddleItems);
+  const materials = usePromise<Estimates.materials.SavedData[]>(fetchMiddleItems);
 
   const filterMiddleItems = (majorItemdName: string) => middleItems.data
     ?.filter(({ 大項目名 }) => 大項目名.value === majorItemdName  );

--- a/src/pages/projEstimate/hooks/useMaterials.ts
+++ b/src/pages/projEstimate/hooks/useMaterials.ts
@@ -1,23 +1,38 @@
 import { usePromise } from '../../../hooks';
+import { fetchMajorItems, fetchMiddleItems } from '../api/fetchMaterials';
 
 
 
 /**
- * Get all yume employees.
- * Will adjust hook name to getYumeEmployees
- * on next refactoring. Or I'll deprecate this in favor
- * of more customizeable useEmployeeOptions Hook
- * @returns
+ * Cached all Materials and expose filter functions.
+ *
+ * This is to save API calls.
  */
-/* export const useMaterials  = () => {
+export const useMaterials  = () => {
+  const majorItems = usePromise<Estimates.majorItems.SavedData[]>(fetchMajorItems);
+  const middleItems = usePromise<Estimates.middleItems.SavedData[]>(fetchMiddleItems);
+  const materials = usePromise<Estimates.middleItems.SavedData[]>(fetchMiddleItems);
 
-  const { data,  error, loading } = usePromise(getEmployees);
+  const filterMiddleItems = (majorItemdName: string) => middleItems.data
+    ?.filter(({ 大項目名 }) => 大項目名.value === majorItemdName  );
 
+  const filterMaterials = ({
+    selMajorItemName, selMiddleItemName,
+  } : {
+    selMajorItemName?: string,
+    selMiddleItemName?: string,
+  }) => materials.data
+    ?.filter(({ 大項目名, 中項目名 }) =>
+      大項目名.value === selMajorItemName ||
+      中項目名.value === selMiddleItemName,
+    );
 
   return {
-    employees: (data as EmployeeTypes.SavedData[]),
-    error,
-    loading,
+    filterMiddleItems,
+    filterMaterials,
+    majorItems,
+    middleItems,
+    materials,
   };
 
-}; */
+};

--- a/src/pages/projEstimate/hooks/useMaterials.ts
+++ b/src/pages/projEstimate/hooks/useMaterials.ts
@@ -9,7 +9,7 @@ import { usePromise } from '../../../hooks';
  * of more customizeable useEmployeeOptions Hook
  * @returns
  */
-export const useMaterials  = () => {
+/* export const useMaterials  = () => {
 
   const { data,  error, loading } = usePromise(getEmployees);
 
@@ -20,4 +20,4 @@ export const useMaterials  = () => {
     loading,
   };
 
-};
+}; */

--- a/src/types/data.estimates.materials.d.ts
+++ b/src/types/data.estimates.materials.d.ts
@@ -4,7 +4,7 @@ declare namespace Estimates.materials {
     原価: kintone.fieldTypes.Number;
     部材名: kintone.fieldTypes.SingleLineText;
     大項目名: kintone.fieldTypes.SingleLineText;
-    ルックアップ: kintone.fieldTypes.Number;
+    中項目: kintone.fieldTypes.Number;
     単位: kintone.fieldTypes.DropDown;
   }
   interface SavedData extends Data {

--- a/src/types/data.estimates.middleItems.d.ts
+++ b/src/types/data.estimates.middleItems.d.ts
@@ -1,7 +1,7 @@
 declare namespace Estimates.middleItems {
   interface Data {
+    大項目: kintone.fieldTypes.Number;
     中項目名: kintone.fieldTypes.SingleLineText;
-    ルックアップ: kintone.fieldTypes.Number;
     大項目名: kintone.fieldTypes.SingleLineText;
     文字列__1行__1: kintone.fieldTypes.SingleLineText;
   }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -33,3 +33,5 @@ interface EnhancedTableProps<T> {
   order: Order;
   orderBy: string;
 }
+
+type Unpack<T> = T extends Promise<infer U> ? U : T;


### PR DESCRIPTION
## 変更

useMaterialsを追加しました。一括で「大項目、中項目、部材」し、絞る関数も公開しています。

返り値は以下の通りです。

 ```
{
    filterMiddleItems: (majorItemdName: string) => Estimates.middleItems.SavedData[],
    filterMaterials: filterMaterials: ( {    selMajorItemName?: string,  selMiddleItemName?: string;
}) => Estimates.materials.SavedData[] | undefined,
    majorItems: {
        data?: Estimates.majorItems.SavedData[];
        error: object;
        loading: boolean;
    },
    middleItems: {
        data?: Estimates.middleItems.SavedData[] ;
        error: object;
        loading: boolean;
    },
    materials: {
        data?: Estimates.middleItems.SavedData[];
        error: object;
        loading: boolean;
    },
  }
```

## なぜこの変更をするのか

通常の関数で実現出来ますが、hook化することで、Reactの通常hookが使えて、ステート操作も出来ます。


## 備考

- 柔軟に使えるように、dataの型はKintoneのレコードのままにしました。
- 当hookにMenuItemの中身の生成も埋め込みするか、考え中。

## テスト

hook自体のテストは書いていませんが、その裏のAPIにテストがあります。

`jest fetchMaterial -t Materials -u`