### PR TITLE
フォームの選択肢に、仮にタイプを追加しました。

### DIFF
--- a/src/pages/projEstimate/form.ts
+++ b/src/pages/projEstimate/form.ts
@@ -17,6 +17,11 @@ import * as Yup from 'yup';
   unitPrice: number,
   price: number,
 }; */
+
+
+export const taxChoices = ['課税', '非課税'] as const;
+export const unitChoices = ['㎡'] as const; //　更新お願いします。
+
 export type TMaterials = TypeOfForm['items'][0];
 export type TKMaterials = keyof TMaterials;
 
@@ -37,8 +42,8 @@ export const initialValues = {
       costPrice: 0,  /* 原価 */
       quantity: 0,   /* 数量 */
       elemProfRate: 0, /* 利益率(部材) */
-      unit: '', /* 単位 */
-      tax: '',  /* 税(課税/非課税) */
+      unit: '' as typeof unitChoices[number], /* 単位 */
+      tax: '' as typeof taxChoices[number],  /* 税(課税/非課税) */
       unitPrice: 0, /* 単価(原価*利益率(部材)) */
       price: 0, /* 金額(課税：(単価*数量) * (1 + (税率/100)), 非課税：(単価*数量)) */
     },
@@ -84,7 +89,7 @@ export const validationSchema = Yup.object(
             .min(0, '0以上の数字を入力してください')
             .required('必須です'), /* 数量 */
           'elemProfRate': Yup.number()
-            .typeError('数値で入力してください')          
+            .typeError('数値で入力してください')
             .min(0, '0以上の数字を入力してください'), /* 利益率(部材) */
           'unit': Yup.string(), /* 単位 */
           'tax': Yup.string(),  /* 税(課税/非課税) */


### PR DESCRIPTION
## 変更

- taxとunitの選択の配列を仮に追加しました。
- taxとunitにタイプを追加しました。

## なぜ

* taxとunitのプールダウンの選択肢を生成するときに使います。

