### PR TITLE
RowContentの柔軟性を改修しました。

### DIFF
--- a/src/pages/projEstimate/QuoteTable/RenderRows.tsx
+++ b/src/pages/projEstimate/QuoteTable/RenderRows.tsx
@@ -23,8 +23,6 @@ export default function RenderRows(props: RenderRowsProps) {
           {values.items.map((item, itemsIdx) => {
             return (
               <RowContent
-                taxRate={values.taxRate}
-                row={item}
                 rowIdx={itemsIdx}
                 removeRow={removeRow}
                 key={item.number}

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -2,8 +2,17 @@
 import { Button, TableCell, TableRow } from '@mui/material';
 import { useFormikContext } from 'formik';
 import { useEffect } from 'react';
-import { TKMaterials, TypeOfForm } from '../form';
+import { Display } from '../fieldComponents/Display';
+import { FormikInput } from '../fieldComponents/FormikInput';
+import { FormikPulldown } from '../fieldComponents/FormikPulldown';
+import { getFieldName, TKMaterials, TypeOfForm } from '../form';
 import InputCellContent from './InputCellContent';
+
+const itemsName = getFieldName('items');
+
+const getItemFieldName = (
+  rowIdx: number, fieldName: TKMaterials,
+) => `${itemsName}[${rowIdx}].${fieldName}`;
 
 export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
   taxRate: number,
@@ -14,6 +23,7 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
   const { setFieldValue } = useFormikContext<TypeOfForm>();
   const { costPrice, quantity, elemProfRate, tax } = row;
 
+
   // 各行の単価・金額の算出処理
   useEffect(() => {
     // 単価の算出処理 : IF(原価 <= 0, 0 , 原価  * ( 1 + (内訳利益率/100)))
@@ -21,7 +31,7 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
     if (!(isNaN(costPrice) || isNaN(elemProfRate)) && ((costPrice) > 0)) {
       newUnitPrice = Math.round(+costPrice * (1 + (+elemProfRate / 100)));
     }
-    setFieldValue(`items[${rowIdx}].unitPrice`, newUnitPrice);
+    setFieldValue(getItemFieldName(rowIdx, 'unitPrice'), newUnitPrice);
 
     // 金額の算出処理 : IF(原価 <= 0, 原価, IF ( 税="課税", (単価*数量) * (1 + (税率/100)), (単価*数量)))
     let newPrice = 0; // 入力値がエラー(数値でない)時は0にする
@@ -38,28 +48,68 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
 
   }, [costPrice, quantity, elemProfRate, tax, taxRate]);
 
-  return (<TableRow >
-    {(Object.keys(row) as TKMaterials[]).map((rowitem) => {
-      return (
-        <TableCell
-          key={`${rowitem}_header`}
-          sx={{
-            padding: 1,
-            verticalAlign: 'top',
-          }}
-        >
-          <InputCellContent fieldName={rowitem} rowIdx={rowIdx} />
-        </TableCell>
-      );
-    })}
-    <TableCell key={`${row}_delBtn`}>
-      <Button
+  return (
+    <TableRow >
+
+      <TableCell>
+        <Display name={getItemFieldName(rowIdx, 'number')} />
+      </TableCell>
+
+      <TableCell>
+        <FormikPulldown name={getItemFieldName(rowIdx, 'majorItem')} options={[]} />
+      </TableCell>
+
+      <TableCell>
+        <FormikPulldown name={getItemFieldName(rowIdx, 'middleItem')} options={[]} />
+      </TableCell>
+
+      <TableCell>
+        <FormikPulldown name={getItemFieldName(rowIdx, 'element')} options={[]} />
+      </TableCell>
+
+      <TableCell>
+        <FormikInput name={getItemFieldName(rowIdx, 'costPrice')} />
+      </TableCell>
+
+      <TableCell>
+        <FormikInput name={getItemFieldName(rowIdx, 'quantity')} />
+      </TableCell>
+
+      <TableCell>
+        <FormikInput name={getItemFieldName(rowIdx, 'elemProfRate')} />
+      </TableCell>
+
+      <TableCell>
+        <FormikPulldown
+        name={getItemFieldName(rowIdx, 'unit')}
+        options={['課税', '非課ｓ税'].map((c) => ({ label: c, value: c }))}
+        />
+      </TableCell>
+
+      <TableCell>
+        <FormikPulldown
+          name={getItemFieldName(rowIdx, 'tax')}
+          options={['課税', '非課税']}
+          />
+      </TableCell>
+
+      <TableCell>
+        <Display name={getItemFieldName(rowIdx, 'unitPrice')} suffix={'円'}/>
+      </TableCell>
+
+      <TableCell>
+        <Display name={getItemFieldName(rowIdx, 'price')} suffix={'円'}/>
+      </TableCell>
+
+
+      <TableCell key={`${row}_delBtn`}>
+        <Button
         variant="outlined"
         onClick={() => removeRow(rowIdx)}
       >
-        -
-      </Button>
-    </TableCell>
-  </TableRow>
+          -
+        </Button>
+      </TableCell>
+    </TableRow>
   );
 };

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -1,11 +1,10 @@
 
 import { Button, TableCell, TableRow } from '@mui/material';
-import { useFormikContext } from 'formik';
-import { useEffect } from 'react';
 import { Display } from '../fieldComponents/Display';
 import { FormikInput } from '../fieldComponents/FormikInput';
 import { FormikPulldown } from '../fieldComponents/FormikPulldown';
-import { getFieldName, taxChoices, TKMaterials, TypeOfForm, unitChoices } from '../form';
+import { getFieldName, taxChoices, TKMaterials, unitChoices } from '../form';
+import { useCalculateRow } from '../hooks/useCalculateRow';
 
 const itemsName = getFieldName('items');
 
@@ -13,39 +12,15 @@ const getItemFieldName = (
   rowIdx: number, fieldName: TKMaterials,
 ) => `${itemsName}[${rowIdx}].${fieldName}`;
 
-export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
-  taxRate: number,
-  row: TypeOfForm['items'][number],
-  rowIdx: number,
-  removeRow: (rowIdx: number) => void
-}) => {
-  const { setFieldValue } = useFormikContext<TypeOfForm>();
-  const { costPrice, quantity, elemProfRate, tax } = row;
+export const RowContent = (
+  { rowIdx,
+    removeRow,
+  }: {
+    rowIdx: number,
+    removeRow: (rowIdx: number) => void
+  }) => {
 
-
-  // 各行の単価・金額の算出処理
-  useEffect(() => {
-    // 単価の算出処理 : IF(原価 <= 0, 0 , 原価  * ( 1 + (内訳利益率/100)))
-    let newUnitPrice = 0; // 入力値がエラー(数値でない)時は0にする
-    if (!(isNaN(costPrice) || isNaN(elemProfRate)) && ((costPrice) > 0)) {
-      newUnitPrice = Math.round(+costPrice * (1 + (+elemProfRate / 100)));
-    }
-    setFieldValue(getItemFieldName(rowIdx, 'unitPrice'), newUnitPrice);
-
-    // 金額の算出処理 : IF(原価 <= 0, 原価, IF ( 税="課税", (単価*数量) * (1 + (税率/100)), (単価*数量)))
-    let newPrice = 0; // 入力値がエラー(数値でない)時は0にする
-    if (+costPrice <= 0 ) {
-      newPrice = costPrice;
-    } else if ((newUnitPrice !== 0) && !(isNaN(quantity))) {
-      if (tax === '課税') {
-        newPrice = Math.round((newUnitPrice * +quantity) * (1 + (+taxRate / 100)));
-      } else { /* 非課税 */
-        newPrice = Math.round(newUnitPrice * +quantity);
-      }
-    }
-    setFieldValue(`items[${rowIdx}].price`, newPrice);
-
-  }, [costPrice, quantity, elemProfRate, tax, taxRate]);
+  useCalculateRow(rowIdx);
 
   return (
     <TableRow >
@@ -101,7 +76,7 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
       </TableCell>
 
 
-      <TableCell key={`${row}_delBtn`}>
+      <TableCell >
         <Button
         variant="outlined"
         onClick={() => removeRow(rowIdx)}

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -5,8 +5,7 @@ import { useEffect } from 'react';
 import { Display } from '../fieldComponents/Display';
 import { FormikInput } from '../fieldComponents/FormikInput';
 import { FormikPulldown } from '../fieldComponents/FormikPulldown';
-import { getFieldName, TKMaterials, TypeOfForm } from '../form';
-import InputCellContent from './InputCellContent';
+import { getFieldName, taxChoices, TKMaterials, TypeOfForm, unitChoices } from '../form';
 
 const itemsName = getFieldName('items');
 
@@ -82,14 +81,14 @@ export const RowContent = ({ taxRate, row, rowIdx, removeRow }: {
       <TableCell>
         <FormikPulldown
         name={getItemFieldName(rowIdx, 'unit')}
-        options={['課税', '非課ｓ税'].map((c) => ({ label: c, value: c }))}
+        options={unitChoices.map((c) => ({ label: c, value: c }))}
         />
       </TableCell>
 
       <TableCell>
         <FormikPulldown
           name={getItemFieldName(rowIdx, 'tax')}
-          options={['課税', '非課税']}
+          options={taxChoices.map((c) => ({ label: c, value: c }))}
           />
       </TableCell>
 

--- a/src/pages/projEstimate/hooks/useCalculateRow.ts
+++ b/src/pages/projEstimate/hooks/useCalculateRow.ts
@@ -1,0 +1,40 @@
+import { useFormikContext } from 'formik';
+import { useEffect } from 'react';
+import { getFieldName, TKMaterials, TypeOfForm } from '../form';
+
+const itemsName = getFieldName('items');
+
+const getItemFieldName = (
+  rowIdx: number, fieldName: TKMaterials,
+) => `${itemsName}[${rowIdx}].${fieldName}`;
+
+export const useCalculateRow = (rowIdx: number) => {
+  const { setFieldValue, values } = useFormikContext<TypeOfForm>();
+  const { taxRate, items } = values;
+  const { costPrice, quantity, elemProfRate, tax } = items[rowIdx];
+
+
+  // 各行の単価・金額の算出処理
+  useEffect(() => {
+    // 単価の算出処理 : IF(原価 <= 0, 0 , 原価  * ( 1 + (内訳利益率/100)))
+    let newUnitPrice = 0; // 入力値がエラー(数値でない)時は0にする
+    if (!(isNaN(costPrice) || isNaN(elemProfRate)) && ((costPrice) > 0)) {
+      newUnitPrice = Math.round(+costPrice * (1 + (+elemProfRate / 100)));
+    }
+    setFieldValue(getItemFieldName(rowIdx, 'unitPrice'), newUnitPrice);
+
+    // 金額の算出処理 : IF(原価 <= 0, 原価, IF ( 税="課税", (単価*数量) * (1 + (税率/100)), (単価*数量)))
+    let newPrice = 0; // 入力値がエラー(数値でない)時は0にする
+    if (+costPrice <= 0 ) {
+      newPrice = costPrice;
+    } else if ((newUnitPrice !== 0) && !(isNaN(quantity))) {
+      if (tax === '課税') {
+        newPrice = Math.round((newUnitPrice * +quantity) * (1 + (+taxRate / 100)));
+      } else { /* 非課税 */
+        newPrice = Math.round(newUnitPrice * +quantity);
+      }
+    }
+    setFieldValue(`items[${rowIdx}].price`, newPrice);
+
+  }, [costPrice, quantity, elemProfRate, tax, taxRate]);
+};


### PR DESCRIPTION
元は #21 と #20 です。 
 
## 変更：

* 各フィールを配列ではなく、単独に並んでいました。
* 計算のロジックをhook化しました。

## なぜ：

* 本フォームのフィールドに依存せず、テーブル列を柔軟に加減出来る。
* 各フィールドのTableCellの見た目など柔軟に修正。
* RowContentから計算のロジックを切り離すことで、別々対応出来るようになり、可読性がよくなると思います。

