### PR TITLE
T107-feat-mitsumori-項目-中項目-部材の連動

### DIFF
--- a/src/pages/projEstimate/QuoteTable/RenderRows.tsx
+++ b/src/pages/projEstimate/QuoteTable/RenderRows.tsx
@@ -1,6 +1,7 @@
 import { TableRow } from '@mui/material';
 import { FieldArrayRenderProps } from 'formik';
 import { TypeOfForm } from '../form';
+import { useMaterials } from '../hooks/useMaterials';
 import { RowContent } from './RowContent';
 
 export type RenderRowsProps = {
@@ -10,7 +11,7 @@ export type RenderRowsProps = {
 
 export default function RenderRows(props: RenderRowsProps) {
   const { arrayHelpers, values } = props;
-  // console.log('row values', values);
+  const { majorItems, middleItems, materials } = useMaterials();
 
   const removeRow = (rowIdx: number) => {
     arrayHelpers.remove(rowIdx);
@@ -25,6 +26,11 @@ export default function RenderRows(props: RenderRowsProps) {
               <RowContent
                 rowIdx={itemsIdx}
                 removeRow={removeRow}
+                materialOptions={{
+                  majorItems: majorItems.data ?? [],
+                  middleItems: middleItems.data ?? [],
+                  materials: materials.data ?? [],
+                }}
                 key={item.number}
               />
             );

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -25,23 +25,41 @@ export const RowContent = (
     materialOptions: TMaterialOptions,
   }) => {
 
-
   useCalculateRow(rowIdx);
-  const { majorItemOpts, middleItemOpts, materialOpts  } = useMaterialsOptions(rowIdx, materialOptions);
+
+  const {
+    majorItemOpts,
+    middleItemOpts,
+    materialOpts,
+    handleMajorItemChange,
+    handleMiddleItemChange,
+    handleMaterialChange,
+  } = useMaterialsOptions(rowIdx, materialOptions);
+
 
   return (
     <TableRow >
 
       <TableCell>
-        <FormikPulldown name={getItemFieldName(rowIdx, 'majorItem')} options={majorItemOpts} />
+        <FormikPulldown
+          name={getItemFieldName(rowIdx, 'majorItem')}
+          handleChange={handleMajorItemChange}
+          options={majorItemOpts}
+          />
       </TableCell>
 
       <TableCell>
-        <FormikPulldown name={getItemFieldName(rowIdx, 'middleItem')} options={middleItemOpts} />
+        <FormikPulldown
+        name={getItemFieldName(rowIdx, 'middleItem')}
+        handleChange={handleMiddleItemChange}
+        options={middleItemOpts} />
       </TableCell>
 
       <TableCell>
-        <FormikPulldown name={getItemFieldName(rowIdx, 'element')} options={materialOpts} />
+        <FormikPulldown
+        name={getItemFieldName(rowIdx, 'element')}
+        handleChange={handleMaterialChange}
+        options={materialOpts} />
       </TableCell>
 
       <TableCell>

--- a/src/pages/projEstimate/QuoteTable/RowContent.tsx
+++ b/src/pages/projEstimate/QuoteTable/RowContent.tsx
@@ -5,6 +5,8 @@ import { FormikInput } from '../fieldComponents/FormikInput';
 import { FormikPulldown } from '../fieldComponents/FormikPulldown';
 import { getFieldName, taxChoices, TKMaterials, unitChoices } from '../form';
 import { useCalculateRow } from '../hooks/useCalculateRow';
+import { useMaterialsOptions } from '../hooks/useMaterialOptions';
+import { TMaterialOptions } from '../hooks/useMaterials';
 
 const itemsName = getFieldName('items');
 
@@ -13,28 +15,33 @@ const getItemFieldName = (
 ) => `${itemsName}[${rowIdx}].${fieldName}`;
 
 export const RowContent = (
-  { rowIdx,
+  {
+    rowIdx,
     removeRow,
+    materialOptions,
   }: {
     rowIdx: number,
-    removeRow: (rowIdx: number) => void
+    removeRow: (rowIdx: number) => void,
+    materialOptions: TMaterialOptions,
   }) => {
 
+
   useCalculateRow(rowIdx);
+  const { majorItemOpts, middleItemOpts, materialOpts  } = useMaterialsOptions(rowIdx, materialOptions);
 
   return (
     <TableRow >
 
       <TableCell>
-        <FormikPulldown name={getItemFieldName(rowIdx, 'majorItem')} options={[]} />
+        <FormikPulldown name={getItemFieldName(rowIdx, 'majorItem')} options={majorItemOpts} />
       </TableCell>
 
       <TableCell>
-        <FormikPulldown name={getItemFieldName(rowIdx, 'middleItem')} options={[]} />
+        <FormikPulldown name={getItemFieldName(rowIdx, 'middleItem')} options={middleItemOpts} />
       </TableCell>
 
       <TableCell>
-        <FormikPulldown name={getItemFieldName(rowIdx, 'element')} options={[]} />
+        <FormikPulldown name={getItemFieldName(rowIdx, 'element')} options={materialOpts} />
       </TableCell>
 
       <TableCell>

--- a/src/pages/projEstimate/api/config.ts
+++ b/src/pages/projEstimate/api/config.ts
@@ -41,12 +41,12 @@ KEstimateAppId,
     query: undefined,
   },
   middleItems: {
-    fields: ['レコード番号', '大項目', '中項目名'] as Array<keyof Estimates.middleItems.SavedData>,
+    fields: ['レコード番号', '大項目', '大項目名', '中項目名'] as Array<keyof Estimates.middleItems.SavedData>,
     query: 'レコード番号 < 10',
   },
   elements: {
 
-    fields: ['部材名', 'レコード番号', '中項目', '原価', '単位'] as Array<keyof Estimates.materials.SavedData>,
+    fields: ['部材名', 'レコード番号', '中項目', '中項目名', '大項目名', '原価', '単位'] as Array<keyof Estimates.materials.SavedData>,
     query: 'レコード番号 < 10',
   },
 };

--- a/src/pages/projEstimate/fieldComponents/FormikInput.tsx
+++ b/src/pages/projEstimate/fieldComponents/FormikInput.tsx
@@ -11,7 +11,7 @@ export const FormikInput = (
   const [field, meta, helpers] = useField(name);
 
   // 入力中一時的にコンポーネント内にInputのステートを管理する
-  const [inputVal, setInputVal] = useState<string | null>(field.value);
+  const [inputVal, setInputVal] = useState<string | null>(null);
   const { error, touched } = meta;
 
   const changeHandlerInput

--- a/src/pages/projEstimate/fieldComponents/FormikPulldown.tsx
+++ b/src/pages/projEstimate/fieldComponents/FormikPulldown.tsx
@@ -2,10 +2,11 @@ import { FormControl, FormHelperText, MenuItem, Select } from '@mui/material';
 import { useField } from 'formik';
 
 export const FormikPulldown = (
-  { name, options } :
+  { name, options, handleChange } :
   {
     name: string,
     options: Options
+    handleChange?: (newVal?: string)=>void
   },
 ) => {
   const [field, meta] = useField(name);
@@ -13,7 +14,11 @@ export const FormikPulldown = (
 
   return (
     <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }} size='small'>
-      <Select {...field} >
+      <Select {...field} onChange={(event)=>{
+
+        if (handleChange) handleChange(event.target.value);
+        field.onChange(event);
+      }}>
         <MenuItem value="">
           <em>-</em>
         </MenuItem>

--- a/src/pages/projEstimate/form.ts
+++ b/src/pages/projEstimate/form.ts
@@ -5,7 +5,7 @@ export const taxChoices = ['課税', '非課税'] as const;
 export const unitChoices = [
   '式', '㎡(平米)', '㎥(立米)', 'm(メートル)', 'ヶ所', '個', 'セット', '本', '枚',
   'ケース', '台', '組', '袋', '箱', 'kg', 't',
-] as const; //　更新お願いします。
+] as const;
 
 export type TMaterials = TypeOfForm['items'][0];
 export type TKMaterials = keyof TMaterials;
@@ -49,8 +49,21 @@ export const initialValues = {
 export type TypeOfForm = typeof initialValues;
 export type KeyOfForm = keyof TypeOfForm;
 
+/*
+ フィールド名取得、ヘルパー
+ */
+
 export const getFieldName = (s: KeyOfForm) => s;
 
+const itemsName = getFieldName('items');
+export const getItemFieldName = (
+  rowIdx: number, fieldName: TKMaterials,
+) => `${itemsName}[${rowIdx}].${fieldName}`;
+
+
+/*
+バリデーション
+*/
 export const validationSchema = Yup.object(
   {
     'projId': Yup

--- a/src/pages/projEstimate/hooks/useCalculateRow.ts
+++ b/src/pages/projEstimate/hooks/useCalculateRow.ts
@@ -1,12 +1,8 @@
 import { useFormikContext } from 'formik';
 import { useEffect } from 'react';
-import { getFieldName, TKMaterials, TypeOfForm } from '../form';
+import { getItemFieldName, TypeOfForm } from '../form';
 
-const itemsName = getFieldName('items');
 
-const getItemFieldName = (
-  rowIdx: number, fieldName: TKMaterials,
-) => `${itemsName}[${rowIdx}].${fieldName}`;
 
 export const useCalculateRow = (rowIdx: number) => {
   const { setFieldValue, values } = useFormikContext<TypeOfForm>();

--- a/src/pages/projEstimate/hooks/useMaterialOptions.ts
+++ b/src/pages/projEstimate/hooks/useMaterialOptions.ts
@@ -1,6 +1,5 @@
 import { useFormikContext } from 'formik';
-import { TypeOfForm } from '../form';
-import { getItemFieldName } from './useCalculateRow';
+import { TypeOfForm, getItemFieldName } from '../form';
 import { TMaterialOptions } from './useMaterials';
 
 

--- a/src/pages/projEstimate/hooks/useMaterialOptions.ts
+++ b/src/pages/projEstimate/hooks/useMaterialOptions.ts
@@ -1,6 +1,7 @@
 import { useFormikContext } from 'formik';
-import { TypeOfForm, getItemFieldName } from '../form';
+import { TypeOfForm, getItemFieldName, unitChoices } from '../form';
 import { TMaterialOptions } from './useMaterials';
+import { produce } from 'immer';
 
 
 
@@ -10,7 +11,7 @@ export const useMaterialsOptions = (
 ) => {
   const { majorItems, middleItems, materials } = materialsOptions;
 
-  const { values, setFieldValue } = useFormikContext<TypeOfForm>();
+  const { values, setFieldValue, setValues } = useFormikContext<TypeOfForm>();
   const { items } = values;
   const { majorItem, middleItem } = items[rowIdx];
 
@@ -19,8 +20,10 @@ export const useMaterialsOptions = (
   /* Change handlers */
 
   const handleMajorItemChange = () => {
-    setFieldValue(getItemFieldName(rowIdx, 'element'), '');
-    setFieldValue(getItemFieldName(rowIdx, 'middleItem'), '');
+    setValues((prev) => produce(prev, (draft ) => {
+      draft.items[rowIdx].element = '';
+      draft.items[rowIdx].middleItem = '';
+    }));
   };
 
   const handleMiddleItemChange = (newVal: string) => {
@@ -35,10 +38,16 @@ export const useMaterialsOptions = (
     if (newVal) {
       const selectedMaterial = materials.find(({ 部材名 })=>部材名.value === newVal);
       if (selectedMaterial) {
-        setFieldValue(getItemFieldName(rowIdx, 'majorItem'), selectedMaterial.大項目名.value);
-        setFieldValue(getItemFieldName(rowIdx, 'middleItem'), selectedMaterial.中項目名.value);
-        setFieldValue(getItemFieldName(rowIdx, 'costPrice'), selectedMaterial.原価.value);
-        setFieldValue(getItemFieldName(rowIdx, 'unit'), selectedMaterial.単位.value);
+      
+        setValues(
+          (prev) => produce(prev, (draft ) => {
+            draft.items[rowIdx].majorItem = selectedMaterial.大項目名.value;
+            draft.items[rowIdx].middleItem = selectedMaterial.中項目名.value;
+            draft.items[rowIdx].costPrice = +selectedMaterial.原価.value; 
+            draft.items[rowIdx].unit = selectedMaterial.単位.value as  typeof unitChoices[number];
+          }),
+        );
+
       }
 
     }

--- a/src/pages/projEstimate/hooks/useMaterialOptions.ts
+++ b/src/pages/projEstimate/hooks/useMaterialOptions.ts
@@ -1,24 +1,58 @@
 import { useFormikContext } from 'formik';
 import { TypeOfForm } from '../form';
+import { getItemFieldName } from './useCalculateRow';
 import { TMaterialOptions } from './useMaterials';
 
 
 
 export const useMaterialsOptions = (
-  rowIdx,
+  rowIdx: number,
   materialsOptions: TMaterialOptions,
 ) => {
   const { majorItems, middleItems, materials } = materialsOptions;
 
-  const { values } = useFormikContext<TypeOfForm>();
+  const { values, setFieldValue } = useFormikContext<TypeOfForm>();
   const { items } = values;
   const { majorItem, middleItem } = items[rowIdx];
+
+
+
+  /* Change handlers */
+
+  const handleMajorItemChange = () => {
+    setFieldValue(getItemFieldName(rowIdx, 'element'), '');
+    setFieldValue(getItemFieldName(rowIdx, 'middleItem'), '');
+  };
+
+  const handleMiddleItemChange = (newVal: string) => {
+    setFieldValue(getItemFieldName(rowIdx, 'element'), '');
+    if (newVal) {
+      const selectedMiddleItem = middleItems.find(({ 中項目名 })=>中項目名.value === newVal);
+      setFieldValue(getItemFieldName(rowIdx, 'majorItem'), selectedMiddleItem?.大項目名.value);
+    }
+  };
+
+  const handleMaterialChange = (newVal: string) => {
+    if (newVal) {
+      const selectedMaterial = materials.find(({ 部材名 })=>部材名.value === newVal);
+      if (selectedMaterial) {
+        setFieldValue(getItemFieldName(rowIdx, 'majorItem'), selectedMaterial.大項目名.value);
+        setFieldValue(getItemFieldName(rowIdx, 'middleItem'), selectedMaterial.中項目名.value);
+        setFieldValue(getItemFieldName(rowIdx, 'costPrice'), selectedMaterial.原価.value);
+        setFieldValue(getItemFieldName(rowIdx, 'unit'), selectedMaterial.単位.value);
+      }
+
+    }
+  };
+
+  /**
+   * Options filters
+   */
 
   const majorItemOpts = majorItems.map<Option>(({ 大項目名 }) => ({
     label: 大項目名.value,
     value: 大項目名.value,
   })) ;
-
 
   const middleItemOpts = middleItems.reduce((accu, { 大項目名, 中項目名 }) => {
     if (!majorItem || 大項目名?.value === majorItem) {
@@ -30,9 +64,8 @@ export const useMaterialsOptions = (
     return accu;
   }, [] as Options);
 
-
-  console.log('materials', materials);
   const materialOpts = materials.reduce((accu, {  中項目名, 部材名 }) => {
+
     if (!middleItem || 中項目名?.value === middleItem) {
       accu.push({
         label: 部材名?.value,
@@ -43,10 +76,15 @@ export const useMaterialsOptions = (
   }, [] as Options);
 
 
+
+
   return {
     majorItemOpts,
     middleItemOpts,
     materialOpts,
+    handleMajorItemChange,
+    handleMiddleItemChange,
+    handleMaterialChange,
   };
 
 

--- a/src/pages/projEstimate/hooks/useMaterialOptions.ts
+++ b/src/pages/projEstimate/hooks/useMaterialOptions.ts
@@ -1,0 +1,53 @@
+import { useFormikContext } from 'formik';
+import { TypeOfForm } from '../form';
+import { TMaterialOptions } from './useMaterials';
+
+
+
+export const useMaterialsOptions = (
+  rowIdx,
+  materialsOptions: TMaterialOptions,
+) => {
+  const { majorItems, middleItems, materials } = materialsOptions;
+
+  const { values } = useFormikContext<TypeOfForm>();
+  const { items } = values;
+  const { majorItem, middleItem } = items[rowIdx];
+
+  const majorItemOpts = majorItems.map<Option>(({ 大項目名 }) => ({
+    label: 大項目名.value,
+    value: 大項目名.value,
+  })) ;
+
+
+  const middleItemOpts = middleItems.reduce((accu, { 大項目名, 中項目名 }) => {
+    if (!majorItem || 大項目名?.value === majorItem) {
+      accu.push({
+        label: 中項目名.value,
+        value: 中項目名.value,
+      });
+    }
+    return accu;
+  }, [] as Options);
+
+
+  console.log('materials', materials);
+  const materialOpts = materials.reduce((accu, {  中項目名, 部材名 }) => {
+    if (!middleItem || 中項目名?.value === middleItem) {
+      accu.push({
+        label: 部材名?.value,
+        value: 部材名?.value,
+      });
+    }
+    return accu;
+  }, [] as Options);
+
+
+  return {
+    majorItemOpts,
+    middleItemOpts,
+    materialOpts,
+  };
+
+
+};

--- a/src/pages/projEstimate/hooks/useMaterials.ts
+++ b/src/pages/projEstimate/hooks/useMaterials.ts
@@ -1,5 +1,5 @@
 import { usePromise } from '../../../hooks';
-import { fetchMajorItems, fetchMiddleItems } from '../api/fetchMaterials';
+import { fetchMajorItems, fetchMaterials, fetchMiddleItems } from '../api/fetchMaterials';
 
 export type TMaterialOptions = {
   majorItems: Estimates.majorItems.SavedData[],
@@ -17,7 +17,7 @@ export type TMaterialOptions = {
 export const useMaterials  = () => {
   const majorItems = usePromise<Estimates.majorItems.SavedData[]>(fetchMajorItems);
   const middleItems = usePromise<Estimates.middleItems.SavedData[]>(fetchMiddleItems);
-  const materials = usePromise<Estimates.materials.SavedData[]>(fetchMiddleItems);
+  const materials = usePromise<Estimates.materials.SavedData[]>(fetchMaterials);
 
   const filterMiddleItems = (majorItemdName: string) => middleItems.data
     ?.filter(({ 大項目名 }) => 大項目名.value === majorItemdName  );


### PR DESCRIPTION
## 関連 (IssueやTrelloリンク)

* #26 
* https://trello.com/c/CiKshtt0

## 変更

1. フィールド名の取得ヘルパー https://github.com/Lorenzras/kokoas/pull/25/commits/7f507119ba999b34efbfd9fc1c5eddd0dcf4c271
2. 選択肢の連動処理を追加しました。 3e8181c8653871c472add3e0fb545f6f574ab9a6
4. FormikPulldownのpropに任意のhandleChangeを追加しました。https://github.com/Lorenzras/kokoas/pull/25/commits/7ecd5b3ee737fbf505a1e247fd393a24da526da2
5. 大項目-中項目-部材それぞれ、handleChangeを追加しました。https://github.com/Lorenzras/kokoas/commit/c75909b0dce63038d4ca073aff83128f158d30f1
6. fix 部材の選択肢が出ない。 a40fb62

## なぜ 

1. 本フォームに合わせたフィールド名を強制したいです。
3. 選択した値によって、選択肢を生成します。
4. Formikの通常のonChangeを実行するほか、その他の処理も可能にします。
5.  「大項目、中項目、部材」それぞれの変更に動作があります。詳しくは https://trello.com/c/CiKshtt0
6.  Fixed #26 

## 残っている課題

1. 関数で動的にフィールド名を取得しているので、毎回実行されます。Typescriptの知識不足で、改善はまだ必要です。目的としては、コンパイル再Typescriptでフォーム名が合っているかどうかのチェックを行います。心あたりがありましたら、対応をお願いします。とりあえず、Issueとして作成します　
#34。