### PR TITLE
28-fix-部材を選択しても、原価と単位に反映しない。

### DIFF
--- a/src/pages/projEstimate/fieldComponents/FormikInput.tsx
+++ b/src/pages/projEstimate/fieldComponents/FormikInput.tsx
@@ -17,7 +17,7 @@ export const FormikInput = (
 
   return (
     <FormControl variant="standard">
-      <Input {...field} error={!!error && touched} onChange={changeHandlerInput} value={undefined} />
+      <Input {...field} error={!!error && touched} onChange={changeHandlerInput} />
       {(!!error && touched) &&
       <FormHelperText error={!!error && touched}>
         {error}


### PR DESCRIPTION
## 変更

FormikInputのpropのvalueをundefinedに代入しましたが、それを削除して、
そのままFormikのuseFieldを利用します。

## なぜ

Fix for #28  

そもそもどうしてvalueはundefinedにしたのかというと、コンポーネントをUncontrolledにすることで、レンダリング回数を抑えたいからです。

でも、onChangeをdebounceにして十分のようで、Controlledに戻します。

## 参考

ControlledとUncontrolledについて

https://ja.reactjs.org/docs/uncontrolled-components.html
https://reactjs.org/docs/uncontrolled-components.html
https://mui.com/material-ui/react-text-field/#uncontrolled-vs-controlled