### PR TITLE
update-linters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,6 @@ module.exports = {
     "react/jsx-indent": [2, 2],
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_",  }],
-    "ignorePatterns": ["types/data.*d.ts"],
+
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,10 +4,11 @@ module.exports = {
     es2021: true,
   },
   extends: [
-
     'plugin:react/recommended',
-    "plugin:import/recommended",
+    'plugin:import/recommended',
     'airbnb-typescript',
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -34,6 +35,7 @@ module.exports = {
     "react/prop-types": "off",
     "react/jsx-indent": [2, 2],
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_",  }],
+    "ignorePatterns": ["types/data.*d.ts"],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,8 +82,8 @@
         "@types/react-dom": "^18.0.4",
         "@types/react-pdf": "^5.7.2",
         "@types/styled-components": "^5.1.25",
-        "@typescript-eslint/eslint-plugin": "^5.28.0",
-        "@typescript-eslint/parser": "^5.28.0",
+        "@typescript-eslint/eslint-plugin": "^5.36.2",
+        "@typescript-eslint/parser": "^5.36.2",
         "autoprefixer": "^10.2.6",
         "babel-loader": "^8.2.2",
         "babel-plugin-direct-import": "^1.0.0",
@@ -113,7 +113,7 @@
         "source-map-loader": "^3.0.0",
         "style-loader": "^2.0.0",
         "ts-jest": "^27.1.4",
-        "typescript": "^4.5.2",
+        "typescript": "^4.8.2",
         "url-loader": "^4.1.1",
         "webpack": "^5.40.0",
         "webpack-bundle-analyzer": "^4.5.0",
@@ -4348,13 +4348,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.3.tgz",
-      "integrity": "sha512-QEgE1uahnDbWEkZlidq7uKB630ny1NN8KbLPmznX+8hYsYpoV1/quG1Nzvs141FVuumuS7O0EpqYw3RB4AVzRg==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
+      "integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.30.3",
-        "@typescript-eslint/type-utils": "5.30.3",
-        "@typescript-eslint/utils": "5.30.3",
+        "@typescript-eslint/scope-manager": "5.36.2",
+        "@typescript-eslint/type-utils": "5.36.2",
+        "@typescript-eslint/utils": "5.36.2",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -4394,13 +4394,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.30.3.tgz",
-      "integrity": "sha512-ddwGEPC3E49DduAUC8UThQafHRE5uc1NE8jdOgl+w8/NrYF50MJQNeD3u4JZrqAXdY9rJz0CdQ9HpNME20CzkA==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
+      "integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.30.3",
-        "@typescript-eslint/types": "5.30.3",
-        "@typescript-eslint/typescript-estree": "5.30.3",
+        "@typescript-eslint/scope-manager": "5.36.2",
+        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/typescript-estree": "5.36.2",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4420,12 +4420,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.3.tgz",
-      "integrity": "sha512-yVJIIUXeo/vv6Alj6lKBvsqnRs5hcxUpN3Dg3aD9Zv6r7p6Nn106jJcr5rnpRHAReEb/aMI2RWrt3JmL17eCVA==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
+      "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
       "dependencies": {
-        "@typescript-eslint/types": "5.30.3",
-        "@typescript-eslint/visitor-keys": "5.30.3"
+        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/visitor-keys": "5.36.2"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4436,11 +4436,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.3.tgz",
-      "integrity": "sha512-IIzakE7OXOqdwPaXhRiPnaZ8OuJJYBLufOffd9fqzkI4IMFIYq8KC7bghdnF7QUJTirURRErQFrJ/w5UpwIqaw==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
+      "integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
       "dependencies": {
-        "@typescript-eslint/utils": "5.30.3",
+        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@typescript-eslint/utils": "5.36.2",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -4461,9 +4462,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.3.tgz",
-      "integrity": "sha512-vshU3pjSTgBPNgfd55JLYngHkXuwQP68fxYFUAg1Uq+JrR3xG/XjvL9Dmv28CpOERtqwkaR4QQ3mD0NLZcE2Xw==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
+      "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -4473,12 +4474,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.3.tgz",
-      "integrity": "sha512-jqVh5N9AJx6+7yRgoA+ZelAFrHezgI9pzI9giv7s84DDOmtpFwTgURcpICDHyz9x6vAeOu91iACZ4dBTVfzIyA==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
+      "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
       "dependencies": {
-        "@typescript-eslint/types": "5.30.3",
-        "@typescript-eslint/visitor-keys": "5.30.3",
+        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/visitor-keys": "5.36.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4513,14 +4514,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.30.3.tgz",
-      "integrity": "sha512-OEaBXGxxdIy35H+jyXfYAMQ66KMJczK9hEhL3gR6IRbWe5PyK+bPDC9zbQNVII6rNFTfF/Mse0z21NlEU+vOMw==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
+      "integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.30.3",
-        "@typescript-eslint/types": "5.30.3",
-        "@typescript-eslint/typescript-estree": "5.30.3",
+        "@typescript-eslint/scope-manager": "5.36.2",
+        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/typescript-estree": "5.36.2",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -4536,11 +4537,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.3.tgz",
-      "integrity": "sha512-ep2xtHOhnSRt6fDP9DSSxrA/FqZhdMF7/Y9fYsxrKss2uWJMbzJyBJ/We1fKc786BJ10pHwrzUlhvpz8i7XzBg==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
+      "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
       "dependencies": {
-        "@typescript-eslint/types": "5.30.3",
+        "@typescript-eslint/types": "5.36.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -24239,9 +24240,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -29032,13 +29033,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.3.tgz",
-      "integrity": "sha512-QEgE1uahnDbWEkZlidq7uKB630ny1NN8KbLPmznX+8hYsYpoV1/quG1Nzvs141FVuumuS7O0EpqYw3RB4AVzRg==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
+      "integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
       "requires": {
-        "@typescript-eslint/scope-manager": "5.30.3",
-        "@typescript-eslint/type-utils": "5.30.3",
-        "@typescript-eslint/utils": "5.30.3",
+        "@typescript-eslint/scope-manager": "5.36.2",
+        "@typescript-eslint/type-utils": "5.36.2",
+        "@typescript-eslint/utils": "5.36.2",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -29058,47 +29059,48 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.30.3.tgz",
-      "integrity": "sha512-ddwGEPC3E49DduAUC8UThQafHRE5uc1NE8jdOgl+w8/NrYF50MJQNeD3u4JZrqAXdY9rJz0CdQ9HpNME20CzkA==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
+      "integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
       "requires": {
-        "@typescript-eslint/scope-manager": "5.30.3",
-        "@typescript-eslint/types": "5.30.3",
-        "@typescript-eslint/typescript-estree": "5.30.3",
+        "@typescript-eslint/scope-manager": "5.36.2",
+        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/typescript-estree": "5.36.2",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.3.tgz",
-      "integrity": "sha512-yVJIIUXeo/vv6Alj6lKBvsqnRs5hcxUpN3Dg3aD9Zv6r7p6Nn106jJcr5rnpRHAReEb/aMI2RWrt3JmL17eCVA==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
+      "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
       "requires": {
-        "@typescript-eslint/types": "5.30.3",
-        "@typescript-eslint/visitor-keys": "5.30.3"
+        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/visitor-keys": "5.36.2"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.3.tgz",
-      "integrity": "sha512-IIzakE7OXOqdwPaXhRiPnaZ8OuJJYBLufOffd9fqzkI4IMFIYq8KC7bghdnF7QUJTirURRErQFrJ/w5UpwIqaw==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
+      "integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
       "requires": {
-        "@typescript-eslint/utils": "5.30.3",
+        "@typescript-eslint/typescript-estree": "5.36.2",
+        "@typescript-eslint/utils": "5.36.2",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.3.tgz",
-      "integrity": "sha512-vshU3pjSTgBPNgfd55JLYngHkXuwQP68fxYFUAg1Uq+JrR3xG/XjvL9Dmv28CpOERtqwkaR4QQ3mD0NLZcE2Xw=="
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
+      "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ=="
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.3.tgz",
-      "integrity": "sha512-jqVh5N9AJx6+7yRgoA+ZelAFrHezgI9pzI9giv7s84DDOmtpFwTgURcpICDHyz9x6vAeOu91iACZ4dBTVfzIyA==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
+      "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
       "requires": {
-        "@typescript-eslint/types": "5.30.3",
-        "@typescript-eslint/visitor-keys": "5.30.3",
+        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/visitor-keys": "5.36.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -29117,24 +29119,24 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.30.3.tgz",
-      "integrity": "sha512-OEaBXGxxdIy35H+jyXfYAMQ66KMJczK9hEhL3gR6IRbWe5PyK+bPDC9zbQNVII6rNFTfF/Mse0z21NlEU+vOMw==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
+      "integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.30.3",
-        "@typescript-eslint/types": "5.30.3",
-        "@typescript-eslint/typescript-estree": "5.30.3",
+        "@typescript-eslint/scope-manager": "5.36.2",
+        "@typescript-eslint/types": "5.36.2",
+        "@typescript-eslint/typescript-estree": "5.36.2",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.3.tgz",
-      "integrity": "sha512-ep2xtHOhnSRt6fDP9DSSxrA/FqZhdMF7/Y9fYsxrKss2uWJMbzJyBJ/We1fKc786BJ10pHwrzUlhvpz8i7XzBg==",
+      "version": "5.36.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
+      "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
       "requires": {
-        "@typescript-eslint/types": "5.30.3",
+        "@typescript-eslint/types": "5.36.2",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -43813,9 +43815,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "dtsgen:custgroups": "npx @kintone/dts-gen --base-url https://rdmuhwtt6gx7.cybozu.com/ --app-id 185 --type-name Data --namespace CustomerGroupTypes -o src/types/data.customerGroup.d.ts",
     "dtsgen:memo": "npx @kintone/dts-gen --base-url https://rdmuhwtt6gx7.cybozu.com/ --app-id 181 --type-name Data --namespace CustomerMemoTypes -o src/types/data.customerMemo.d.ts",
     "dtsgen:projType": "npx @kintone/dts-gen --base-url https://rdmuhwtt6gx7.cybozu.com/ --app-id 190 --type-name Data --namespace ConstructionTypes -o src/types/data.constructionType.d.ts",
-    "dtsgen:projDetails": "npx @kintone/dts-gen --base-url https://rdmuhwtt6gx7.cybozu.com/ --app-id 194 --type-name Data --namespace ProjectDetails -o src/types/data.constructionDetails.d.ts"
+    "dtsgen:projDetails": "npx @kintone/dts-gen --base-url https://rdmuhwtt6gx7.cybozu.com/ --app-id 194 --type-name Data --namespace ProjectDetails -o src/types/data.constructionDetails.d.ts",
+    "dtsgen:estimatesMajorItems": "npx @kintone/dts-gen --base-url https://rdmuhwtt6gx7.cybozu.com/ --app-id 67 --type-name Data --namespace Estimates.majorItems -o src/types/data.estimates.majorItems.d.ts",
+    "dtsgen:estimatesMiddleItems": "npx @kintone/dts-gen --base-url https://rdmuhwtt6gx7.cybozu.com/ --app-id 68 --type-name Data --namespace Estimates.middleItems -o src/types/data.estimates.middleItems.d.ts",
+    "dtsgen:estimatesMaterials": "npx @kintone/dts-gen --base-url https://rdmuhwtt6gx7.cybozu.com/ --app-id 69 --type-name Data --namespace Estimates.materials -o src/types/data.estimates.materials.d.ts",
+    "dtsgen:estimates": "npx @kintone/dts-gen --base-url https://rdmuhwtt6gx7.cybozu.com/ --app-id 202 --type-name Data --namespace Estimates.main -o src/types/data.estimates.main.d.ts"
   },
   "keywords": [
     "Autoprefixer",
@@ -50,8 +54,8 @@
     "@types/react-dom": "^18.0.4",
     "@types/react-pdf": "^5.7.2",
     "@types/styled-components": "^5.1.25",
-    "@typescript-eslint/eslint-plugin": "^5.28.0",
-    "@typescript-eslint/parser": "^5.28.0",
+    "@typescript-eslint/eslint-plugin": "^5.36.2",
+    "@typescript-eslint/parser": "^5.36.2",
     "autoprefixer": "^10.2.6",
     "babel-loader": "^8.2.2",
     "babel-plugin-direct-import": "^1.0.0",
@@ -81,7 +85,7 @@
     "source-map-loader": "^3.0.0",
     "style-loader": "^2.0.0",
     "ts-jest": "^27.1.4",
-    "typescript": "^4.5.2",
+    "typescript": "^4.8.2",
     "url-loader": "^4.1.1",
     "webpack": "^5.40.0",
     "webpack-bundle-analyzer": "^4.5.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "allowJs": true,
     "lib": ["es5","es2017", "es6", "dom", "dom.iterable"],
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
     "importHelpers": true,


### PR DESCRIPTION
## 何

- typescriptのバージョンアップ
- eslintのバージョンアップ
- eslintにtypescriptの推薦プラグイン追加
- package.jsonに見積もりのdtsgenを追加。
- anyを禁止にしました。

## なぜ

- パフォーマンス向上のため、更新しました。
- Kintoneのdtsgenはnamespaceに二つのinterfaceを生成していますが、二つ目はno-unused-var（使用されていない変数）として、扱っています。
- バグ原因をより早く突き止めるように、anyを禁止ました。