### PR TITLE
見積もり部材毎のフィールド幅を調整する

### DIFF
--- a/src/pages/projEstimate/fieldComponents/Display.tsx
+++ b/src/pages/projEstimate/fieldComponents/Display.tsx
@@ -11,7 +11,7 @@ export const Display = ({
   const [field] = useField(name);
 
   return (
-    <Typography variant='body2'>
+    <Typography variant='body2' sx={{ minWidth: 70 }}>
       {field.value}
       {suffix}
     </Typography>

--- a/src/pages/projEstimate/fieldComponents/FormikAutocomplete.tsx
+++ b/src/pages/projEstimate/fieldComponents/FormikAutocomplete.tsx
@@ -21,7 +21,7 @@ export const FormikAutocomplete = (
     }, 1000), [JSON.stringify(options)]);
 
   return (
-    <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }} size='small'>
+    <FormControl variant="standard" sx={{ minWidth: 100 }} size='small'>
       <Autocomplete {...field}
         freeSolo
         options={options.map(({ value }) => value)}

--- a/src/pages/projEstimate/fieldComponents/FormikInput.tsx
+++ b/src/pages/projEstimate/fieldComponents/FormikInput.tsx
@@ -35,6 +35,7 @@ export const FormikInput = (
         }}
         value={inputVal === null ? field.value : inputVal} // inputValは空なら、入力中ではないということなので、本フォームのfield.valueを反映させる。
         onChange={changeHandlerInput}
+        sx={{ minWidth: 60 }}
       />
       {(!!error && touched) &&
         <FormHelperText error={!!error && touched}>

--- a/src/pages/projEstimate/fieldComponents/FormikPulldown.tsx
+++ b/src/pages/projEstimate/fieldComponents/FormikPulldown.tsx
@@ -13,7 +13,7 @@ export const FormikPulldown = (
   const { touched, error } = meta;
 
   return (
-    <FormControl variant="standard" sx={{ m: 1, minWidth: 120 }} size='small'>
+    <FormControl variant="standard" sx={{ minWidth: 60 }} size='small'>
       <Select {...field} onChange={(event)=>{
 
         if (handleChange) handleChange(event.target.value);


### PR DESCRIPTION
**変更**
---

- 部材毎の見積もりテーブル内、セル幅の調整をします。

**変更理由**
---

- 原価、数量等の入力値が確認できないため
- #48 

**スクリーンショット**
---
![84screenshot](https://user-images.githubusercontent.com/87287796/189822423-8f281c41-a461-4c4f-a5c3-ad26efe69625.png)
