### PR TITLE
99 fix 見積画面でステータスが保存されない

### DIFF
--- a/src/pages/projEstimate/api/saveForm.ts
+++ b/src/pages/projEstimate/api/saveForm.ts
@@ -5,6 +5,7 @@ const convertToKintone = ({
   customerName, projName, projType,
   profitRate, taxRate,
   items, projId,
+  status,
 }: TypeOfForm) => {
 
   /* itemsの変換処理 */
@@ -40,7 +41,7 @@ const convertToKintone = ({
     利益率: { value: profitRate.toString() },
     税率: { value: taxRate.toString() },
     内訳: kintoneItems,
-
+    estimateStatus: { value: status },
   };
 
   return kintoneRecord;

--- a/src/types/data.estimates.main.d.ts
+++ b/src/types/data.estimates.main.d.ts
@@ -10,6 +10,7 @@ declare namespace Estimates.main {
     顧客名: kintone.fieldTypes.SingleLineText;
     contractPrice: kintone.fieldTypes.Number;
     税率: kintone.fieldTypes.Number;
+    estimateStatus: kintone.fieldTypes.SingleLineText;
     voidedEnvelopes: kintone.fieldTypes.SingleLineText;
     工事種別名: kintone.fieldTypes.SingleLineText;
     signMethod: kintone.fieldTypes.SingleLineText;


### PR DESCRIPTION
## 変更

- 見積アプリのタイプ定義の更新
- 保存処理にstatusを保存するよう追加しました。

## 変更理由

- fixed #99 

## 備考

- #100 にも修正がありますが、これからのPRのために、優先にdevelopmentに反映させたいので、本PRを作成しました。