### PR TITLE
T140 見積もり画面で部材ごとのデフォールト利益率は工事種別から引っ張る。

### DIFF
--- a/src/pages/projEstimate/QuoteTable/rowActions/QtRowAddDelete.tsx
+++ b/src/pages/projEstimate/QuoteTable/rowActions/QtRowAddDelete.tsx
@@ -2,7 +2,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { IconButton, Menu, MenuItem } from '@mui/material';
 import { FieldArrayRenderProps } from 'formik';
 import { useState } from 'react';
-import { initialValues, TypeOfForm } from '../../form';
+import { initialValues, TMaterials, TypeOfForm } from '../../form';
 import { v4 as uuidv4 } from 'uuid';
 
 export const QtRowAddDelete = ({
@@ -16,12 +16,12 @@ export const QtRowAddDelete = ({
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const { form, remove, insert } = arrayHelpers;
-  const { items } = form.values as TypeOfForm;
+  const { items, projTypeProfit } = form.values as TypeOfForm;
   const currentItem = items[rowIdx];
 
   const isJustOneRow = items.length === 1;
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleOpenMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
@@ -35,18 +35,29 @@ export const QtRowAddDelete = ({
   };
 
   const handleAddToRowBelow = () => {
-    insert(rowIdx + 1, { ...initialValues.items[0], key: uuidv4() });
+    const newRow: TMaterials = {
+      ...initialValues.items[0],
+      key: uuidv4(),
+      elemProfRate: projTypeProfit,
+    };
+
+    insert(rowIdx + 1, newRow);
     handleClose();
   };
 
   const handleCopyToRowBelow = () => {
-    insert(rowIdx + 1, { ...currentItem, key: uuidv4() });
+    const newRow: TMaterials = {
+      ...currentItem,
+      key: uuidv4(),
+      elemProfRate: projTypeProfit,
+    };
+    insert(rowIdx + 1, newRow);
     handleClose();
   };
 
   return (
     <>
-      <IconButton onClick={handleClick} >
+      <IconButton onClick={handleOpenMenu} >
         <MoreVertIcon />
       </IconButton>
       <Menu

--- a/src/pages/projEstimate/hooks/useMaterialOptions.ts
+++ b/src/pages/projEstimate/hooks/useMaterialOptions.ts
@@ -47,13 +47,12 @@ export const useMaterialsOptions = (
             draft.items[rowIdx].majorItem = selectedMaterial.大項目名.value;
             draft.items[rowIdx].middleItem = selectedMaterial.中項目名.value;
             draft.items[rowIdx].costPrice = +selectedMaterial.原価.value;
-            draft.items[rowIdx].elemProfRate = +selectedMaterial.部材利益率.value;
             draft.items[rowIdx].unit = newUnit;
           }),
         );
       }
     }
-  }, [rowIdx, setValues, materials]); 
+  }, [rowIdx, setValues, materials]);
 
   /**
    * Options filters


### PR DESCRIPTION
## 変更

- 行追加のタイプの定義をより安全に。
- 行の利益率をprojTypeProfit（工事種別利益）に修正

## 変更理由

- Formikのinsertの引数はanyになっているからです。
- https://trello.com/c/fpMuGozY