### PR TITLE
見積りダイアログon closeの設定修正

### DIFF
--- a/src/pages/projEstimate/fieldComponents/dialogActions/ConfirmationDialogRaw.tsx
+++ b/src/pages/projEstimate/fieldComponents/dialogActions/ConfirmationDialogRaw.tsx
@@ -38,6 +38,7 @@ export const ConfirmationDialogRaw = (props: ConfirmationDialogRawProps) => {
       sx={{ '& .MuiDialog-paper': { width: '80%', maxHeight: 435 } }}
       maxWidth="xs"
       open={open}
+      onClose={() => onClose()}
       {...other}
     >
       <DialogTitle>


### PR DESCRIPTION
**変更**

既存の見積りを選択するダイアログで、ダイアログの外側をクリックした際にダイアログが閉じるように設定する

**変更理由**

操作性の向上のため